### PR TITLE
updating to correct prerender service URL

### DIFF
--- a/backend_generator.py
+++ b/backend_generator.py
@@ -29,7 +29,7 @@ parser = optparse.OptionParser(description=desc)
 parser.add_option('-n', '--hostname',
                   dest='hostname',
                   help='prerender.io rendering backend hostname',
-                  default='prerender.herokuapp.com')
+                  default='service.prerender.io')
 parser.add_option('-p', '--port',
                   dest='port',
                   help='prerender.io rendering backend port',

--- a/prerender.vcl
+++ b/prerender.vcl
@@ -36,7 +36,7 @@ sub vcl_recv {
 
 sub vcl_miss {
     if (req.backend == prerender) {
-        set bereq.http.Host = "prerender.herokuapp.com";
+        set bereq.http.Host = "service.prerender.io";
         set bereq.http.X-Real-IP = client.ip;
         set bereq.http.X-Forwarded-For = client.ip;
 

--- a/prerender_backend.vcl
+++ b/prerender_backend.vcl
@@ -3,7 +3,7 @@
 # backend_generator.py. See README.md for details.
 #
 backend prerender {
-    .host = "prerender.herokuapp.com";
+    .host = "service.prerender.io";
     .port = "80";
 }
 


### PR DESCRIPTION
prerender.herokuapp.com was deprecated a long time ago and we now use service.prerender.io to point to our current infrastructure.

Please update as soon as possible.

Thanks so much!
